### PR TITLE
feat: getExplorers function and updated Blockscout explorer URL

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -101,7 +101,7 @@
       },
       {
         "type": "explorer",
-        "url": "https://zetachain-athens-2.blockscout.com",
+        "url": "https://zetachain-athens-3.blockscout.com",
         "tx": "/tx/${tx}",
         "address": "/address/${address}"
       }

--- a/src/getExplorers.ts
+++ b/src/getExplorers.ts
@@ -1,0 +1,30 @@
+import { NetworksSchema } from "./types";
+import networks from "./networks";
+
+export const getExplorers = (
+  input: string,
+  inputType: "address" | "tx",
+  networkKey: keyof NetworksSchema
+): string[] => {
+  const network = networks[networkKey as keyof typeof networks];
+  if (!network) {
+    throw new Error("Network not found");
+  }
+
+  if (!("apps" in network) || !Array.isArray(network.apps)) {
+    throw new Error("Explorers not available for the provided network");
+  }
+
+  const explorerApps = network.apps.filter((app) => app.type === "explorer");
+
+  const urls: string[] = [];
+  for (const app of explorerApps) {
+    if (inputType === "address" && app.address) {
+      urls.push(app.url + app.address.replace("${address}", input));
+    } else if (inputType === "tx" && app.tx) {
+      urls.push(app.url + app.tx.replace("${tx}", input));
+    }
+  }
+
+  return urls;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./getEndpoints";
 export * from "./getHardhatConfigNetworks";
 export * from "./getSupportedNetworks";
+export * from "./getExplorers";
 export { default as networks } from "./networks";

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@
 export type ApiType =
   | "evm"
   | "tendermint-rpc"
+  | "tendermint-http"
   | "cosmos-http"
   | "tendermint-ws"
   | "cosmos-grpc"


### PR DESCRIPTION
Returns a list of explorer URL.

```ts
getExplorers("0xb262d847efd185b29bc1ca01f6ebdc0104dd689b", "address", "zeta_testnet")
```

```ts
[
  'https://explorer.zetachain.com/address/0xb262d847efd185b29bc1ca01f6ebdc0104dd689b',
  'https://zetachain-athens-2.blockscout.com/address/0xb262d847efd185b29bc1ca01f6ebdc0104dd689b'
]
```

Also, updated the Blockscout explorer URL.