### PR TITLE
feat: added a new BSC testnet RPC

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -203,6 +203,10 @@
     },
     "api": [
       {
+        "url": "https://bsc-testnet.blockpi.network/v1/rpc/public",
+        "type": "evm"
+      },
+      {
         "url": "https://data-seed-prebsc-1-s1.binance.org:8545",
         "type": "evm"
       }


### PR DESCRIPTION
I'm getting constant "transaction underpriced" errors (no matter the `gas` and `gasPrice` values), so I'm proposing we switch to a different RPC endpoint by default.