### PR TITLE
feat: getNetworkName

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -1,6 +1,19 @@
 {
   "mumbai_testnet": {
     "chain_id": 80001,
+    "chain_aliases": [
+      "mumbai",
+      "polygon_mumbai",
+      "polygon_testnet",
+      "mumbai_chain",
+      "mumbai_network",
+      "polygon-mumbai",
+      "polygon-testnet",
+      "mumbai-chain",
+      "mumbai-network",
+      "mumbai-testnet",
+      "maticmum"
+    ],
     "chain_name": "Mumbai Testnet",
     "fees": {
       "assets": [
@@ -45,6 +58,10 @@
   "btc_testnet": {
     "chain_id": 1,
     "chain_name": "Bitcoin Testnet",
+    "chain_aliases": [
+      "tbtc",
+      "btc-testnet"
+    ],
     "assets": [
       {
         "denoms": [
@@ -161,6 +178,15 @@
   "zeta_testnet": {
     "chain_id": 7001,
     "chain_name": "Zeta Testnet",
+    "chain_aliases": [
+      "zeta",
+      "zeta_chain",
+      "zeta_network",
+      "zeta-chain",
+      "zeta-network",
+      "zeta-testnet",
+      "athens"
+    ],
     "bech32_prefix": "zeta",
     "assets": [
       {
@@ -270,6 +296,12 @@
   "bsc_testnet": {
     "chain_id": 97,
     "chain_name": "Binance Smart Chain Testnet",
+    "chain_aliases": [
+      "bsc",
+      "bsc-testnet",
+      "bsc-chain",
+      "bsc-network"
+    ],
     "assets": [
       {
         "denoms": [
@@ -317,6 +349,14 @@
   "goerli_testnet": {
     "chain_id": 5,
     "chain_name": "Goerli Testnet",
+    "chain_aliases": [
+      "goerli",
+      "goerli_chain",
+      "goerli_network",
+      "goerli-chain",
+      "goerli-network",
+      "goerli-testnet"
+    ],
     "assets": [
       {
         "denoms": [

--- a/data/networks.json
+++ b/data/networks.json
@@ -180,12 +180,13 @@
     "chain_name": "Zeta Testnet",
     "chain_aliases": [
       "zeta",
+      "athens",
       "zeta_chain",
       "zeta_network",
       "zeta-chain",
       "zeta-network",
       "zeta-testnet",
-      "athens"
+      "zetachain-athens-testnet"
     ],
     "bech32_prefix": "zeta",
     "assets": [

--- a/src/getNetworkName.ts
+++ b/src/getNetworkName.ts
@@ -1,0 +1,22 @@
+import networks from "./networks";
+
+export const getNetworkName = (alias: string): string | null => {
+  const lowerCaseAlias = alias.toLowerCase();
+  for (const networkKey in networks) {
+    const network = networks[networkKey as keyof typeof networks] as {
+      chain_aliases?: string[];
+    };
+    if (
+      network.chain_aliases &&
+      network.chain_aliases.some(
+        (networkAlias) => networkAlias.toLowerCase() === lowerCaseAlias
+      )
+    ) {
+      return networkKey;
+    }
+    if (networkKey.toLowerCase() === lowerCaseAlias) {
+      return networkKey;
+    }
+  }
+  return null;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,6 +592,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-walk@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
+  integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
+
 dotenv@^16.1.4:
   version "16.1.4"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.1.4.tgz#67ac1a10cd9c25f5ba604e4e08bc77c0ebe0ca8c"
@@ -1134,6 +1139,14 @@ glob@^7.1.3, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
+  dependencies:
+    min-document "^2.19.0"
+    process "^0.11.10"
+
 globals@^13.19.0:
   version "13.20.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
@@ -1592,6 +1605,13 @@ mimic-fn@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==
+  dependencies:
+    dom-walk "^0.1.0"
+
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -1811,6 +1831,11 @@ prettier@^2.6.2, prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
 punycode@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
There is no standard for chain labels, so:

```ts
getNetworkName("mumbai_network") // => "mumbai_testnet"
getNetworkName("MuMbaI-tESTnet") // => "mumbai_testnet"
```

For example, viem, which is used by wagmi, which is used by Rainbow Kit calls Polygon Mumbai `maticmum` 🫠

We might make this smarter, by checking for `-testnet` and `-network` automatically, but we'll still have to keep wierd names like above.