### PR TITLE
refactor: top-level imports both in browser and in Node.js, getChainId

### DIFF
--- a/src/getChainId.ts
+++ b/src/getChainId.ts
@@ -1,0 +1,22 @@
+import networks from "./networks";
+
+export const getChainId = (chainNameOrAlias: string): number | null => {
+  if (networks.hasOwnProperty(chainNameOrAlias)) {
+    return networks[chainNameOrAlias as keyof typeof networks].chain_id;
+  }
+
+  // Iterate through networks to check aliases
+  for (const key in networks) {
+    if (networks.hasOwnProperty(key)) {
+      const chain: any = networks[key as keyof typeof networks];
+      if (
+        chain.chain_aliases &&
+        chain.chain_aliases.includes(chainNameOrAlias)
+      ) {
+        return chain.chain_id;
+      }
+    }
+  }
+
+  return null;
+};

--- a/src/getHardhatConfigNetworks/getHardhatConfigNetworks.ts
+++ b/src/getHardhatConfigNetworks/getHardhatConfigNetworks.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 
-import networks from "./networks";
+import networks from "../networks";
 
 interface Config {
   [key: string]: {

--- a/src/getHardhatConfigNetworks/index.ts
+++ b/src/getHardhatConfigNetworks/index.ts
@@ -1,0 +1,18 @@
+let getHardhatConfigNetworksExport;
+
+if (
+  typeof process !== "undefined" &&
+  process.versions &&
+  process.versions.node
+) {
+  getHardhatConfigNetworksExport =
+    require("./getHardhatConfigNetworks").getHardhatConfigNetworks;
+} else {
+  getHardhatConfigNetworksExport = () => {
+    throw new Error(
+      "getHardhatConfigNetworks is not available in this environment"
+    );
+  };
+}
+
+export default getHardhatConfigNetworksExport;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./getEndpoints";
 export * from "./getExplorers";
 export * from "./getSupportedNetworks";
 export * from "./getNetworkName";
-export { default as networks } from "./networks";
+export * from "./getChainId";
 
+export { default as networks } from "./networks";
 export { default as getHardhatConfigNetworks } from "./getHardhatConfigNetworks";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./getEndpoints";
 export * from "./getExplorers";
-export * from "./getHardhatConfigNetworks";
 export * from "./getSupportedNetworks";
+export * from "./getNetworkName";
 export { default as networks } from "./networks";
+
+export { default as getHardhatConfigNetworks } from "./getHardhatConfigNetworks";


### PR DESCRIPTION
## Refactor

All functions in the `networks` package are compatible with both browser and node.js environments.

`getHardhatConfigNetworks` is only compatible (and useful) in the node.js env, because it's running `dotenv.config()`.

Since it's a simple package I want all functions to be importable from a single top-level namespace.

For Hardhat:

```ts
import { getHardhatConfigNetworks } from "@zetachain/networks";
```

For frontend, for example:

```ts
import {
  getEndpoints,
  getExplorers,
  getNetworkName,
  networks,
} from "@zetachain/networks"
```

This PR creates a wrapper around functions like `getHardhatConfigNetworks`, so that they are imported only when running in node.js environment.

Seems to be working. I think this is an ok solution for now. If we have more Node.js-only functions, we can think of something else.

## `getChainId`

Helper function to get chain ID from chain label (or any of the aliases).