### PR TITLE
fix: added HTTP to F5 URL

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -297,7 +297,7 @@
         "type": "cosmos-http"
       },
       {
-        "url": "zetachain-grpc.f5nodes.com",
+        "url": "https://zetachain-grpc.f5nodes.com",
         "type": "cosmos-grpc"
       }
     ]


### PR DESCRIPTION
Incorrectly formatted URL broke the table in the docs:

<img width="1840" alt="Screenshot 2023-12-05 at 12 45 36" src="https://github.com/zeta-chain/networks/assets/332151/0c60e8c2-c53e-4a5a-90d0-7003f24323b2">

The API checker skipped it, because we currently don't check gRPC.