### PR TITLE
Add developnet config

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -571,5 +571,121 @@
         "type": "evm"
       }
     ]
+  },
+  "zeta_developnet": {
+    "chain_id": 101,
+    "chain_name": "ZetaChain developnet",
+    "chain_aliases": [
+      "developnet",
+      "zetachain_developnet",
+      "zeta_chain_developnet",
+      "zeta_network_developnet",
+      "zeta-chain-developnet",
+      "zeta-network-developnet",
+      "zeta-developnet"
+    ],
+    "bech32_prefix": "zeta",
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "azeta",
+            "exponent": 0
+          },
+          {
+            "denom": "zeta",
+            "exponent": 18
+          }
+        ],
+        "base": "azeta",
+        "symbol": "ZETA"
+      }
+    ],
+    "apps": [],
+    "fees": {
+      "assets": [
+        {
+          "denom": "azeta",
+          "gas": 5000000,
+          "gas_price": 80000000000
+        }
+      ]
+    },
+    "staking": {
+      "denom": "azeta"
+    },
+    "api": [
+      {
+        "url": "https://develop-zevm-0.zetachain.network",
+        "type": "evm"
+      },
+      {
+        "url": "https://develop-cometbft-0.zetachain.network",
+        "type": "tendermint-rpc"
+      },
+      {
+        "url": "https://develop-cosmos-api-0.zetachain.network",
+        "type": "cosmos-http"
+      },
+      {
+        "url": "wss://develop-cometbft-0.zetachain.network/websocket",
+        "type": "tendermint-ws"
+      },
+      {
+        "url": "https://develop-zevm-1.zetachain.network",
+        "type": "evm"
+      },
+      {
+        "url": "https://develop-cometbft-1.zetachain.network",
+        "type": "tendermint-rpc"
+      },
+      {
+        "url": "https://develop-cosmos-api-1.zetachain.network",
+        "type": "cosmos-http"
+      },
+      {
+        "url": "wss://develop-cometbft-1.zetachain.network/websocket",
+        "type": "tendermint-ws"
+      }
+    ]
+  },
+  "eth_developnet": {
+    "chain_id": 1337,
+    "chain_name": "ETH developnet",
+    "chain_aliases": [
+      "eth-developnet"
+    ],
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "wei",
+            "exponent": 0
+          },
+          {
+            "denom": "eth",
+            "exponent": 18
+          }
+        ],
+        "base": "eth",
+        "symbol": "ETH"
+      }
+    ],
+    "apps": [],
+    "fees": {
+      "assets": [
+        {
+          "denom": "eth",
+          "gas": 2100000,
+          "gas_price": 38000000000
+        }
+      ]
+    },
+    "api": [
+      {
+        "url": "https://develop-eth.zetachain.network",
+        "type": "evm"
+      }
+    ]
   }
 }


### PR DESCRIPTION
https://develop-info.zetachain.network

I'm not sure this is configured correctly.

Update: this is not particularly useful without updating the network addresses in `protocol-contracts` at the same time.

I was able to deploy the contract template but I had to hardcode the system contract address:
<details>

```
➜  template git:(main) ✗ npx hardhat deploy --network zeta_developnet --verbose
  hardhat:core:vars:varsManager Creating a new instance of VarsManager +0ms
  hardhat:core:vars:varsManager Loading ENV variables if any +0ms
  hardhat:core:config Loading Hardhat config from /home/alex/workspace/github.com/zeta-chain/template/hardhat.config.ts +0ms
  hardhat:core:hre Creating HardhatRuntimeEnvironment +0ms
  hardhat:core:global-dir Looking up Client Id at /home/alex/.local/share/hardhat-nodejs/analytics.json +0ms
  hardhat:core:global-dir Client Id found: e30fc31f-1213-4a6d-b437-5c529320ec77 +1ms
  hardhat:core:hre Running task deploy +4ms
{ json: false, name: 'MyContract' }
here1
  hardhat:core:hre Creating provider for network zeta_developnet +7ms
here2
0x91d18e54DAf4F677cB28167158d6dd21F6aB3921
here3
here4
here5
🔑 Using account: 0x7c6768371680BeB308f70Aa86080630c79d99675

🚀 Successfully deployed contract on zeta_developnet.
📜 Contract address: 0x4081c0DE49EA02B543F7824A3703e7b9c9ef1CB6
🌍 ZetaScan: https://explorer.zetachain.com/address/0x4081c0DE49EA02B543F7824A3703e7b9c9ef1CB6
🌍 Blockcsout: https://zetachain.blockscout.com/address/0x4081c0DE49EA02B543F7824A3703e7b9c9ef1CB6

  hardhat:core:cli Killing Hardhat after successfully running task deploy +0ms
  ```

</details>

Part of DEVOP-642