### PR TITLE
Move f5nodes RPC endpoints to Mainnet list

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -499,6 +499,18 @@
       {
         "url": "https://zetachain-jsonrpc.lavenderfive.com:443",
         "type": "evm"
+      },
+      {
+        "url": "https://zetachain-rpc.f5nodes.com",
+        "type": "tendermint-rpc"
+      },
+      {
+        "url": "https://zetachain-api.f5nodes.com",
+        "type": "cosmos-http"
+      },
+      {
+        "url": "https://zetachain-grpc.f5nodes.com",
+        "type": "cosmos-grpc"
       }
     ]
   },
@@ -609,18 +621,6 @@
       },
       {
         "url": "https://zetachain-testnet-grpc.itrocket.net:14090",
-        "type": "cosmos-grpc"
-      },
-      {
-        "url": "https://zetachain-rpc.f5nodes.com",
-        "type": "tendermint-rpc"
-      },
-      {
-        "url": "https://zetachain-api.f5nodes.com",
-        "type": "cosmos-http"
-      },
-      {
-        "url": "https://zetachain-grpc.f5nodes.com",
         "type": "cosmos-grpc"
       }
     ]


### PR DESCRIPTION
F5nodes is NOT in fact running Athens RPCs like our docs say they are. 

Move f5nodes RPC endpoints from Athens to Mainnet list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new network configurations for enhanced connectivity options, including Tendermint RPC and multiple Cosmos-related endpoints.
  
- **Bug Fixes**
	- Removed outdated network configurations to streamline the available connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->