### PR TITLE
chore: rename base_testnet to base_sepolia

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -54,7 +54,7 @@
       }
     ]
   },
-  "base_testnet": {
+  "base_sepolia": {
     "chain_id": 84532,
     "chain_aliases": [
       "base",


### PR DESCRIPTION
To match what's on chain:

https://zetachain-athens.blockpi.network/lcd/v1/public/zeta-chain/observer/supportedChains