### PR TITLE
feat: add Avalanche C-Chain Fuji and Arbitrum Sepolia (Testnets) in the network list

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -1,4 +1,134 @@
 {
+  "avalanche_testnet": {
+    "chain_id": 43113,
+    "chain_aliases": [
+      "avalanche_c",
+      "avalanche_c_network",
+      "avalanche_c_chain",
+      "avalanche_c_fuji_testnet",
+      "avalanche_c_fuji",
+      "avalanche-c",
+      "avalanche-c-network",
+      "avalanche-c-chain",
+      "avalanche-c-fuji-testnet",
+      "avalanche-c-fuji"
+    ],
+    "chain_name": "Avalanche C-Chain Fuji",
+    "fees": {
+      "assets": [
+        {
+          "denom": "avax",
+          "gas": 5000000,
+          "gas_price": 1000000000
+        }
+      ]
+    },
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "wei",
+            "exponent": 0
+          },
+          {
+            "denom": "avax",
+            "exponent": 18
+          }
+        ],
+        "base": "avax",
+        "symbol": "AVAX"
+      }
+    ],
+    "apps": [
+      {
+        "type": "explorer",
+        "url": "https://subnets-test.avax.network/c-chain",
+        "tx": "/tx/${tx}",
+        "address": "/address/${address}"
+      }
+    ],
+    "api": [
+      {
+        "url": "https://api.avax-test.network/ext/bc/C/rpc",
+        "type": "evm"
+      },
+      {
+        "url": "https://ava-testnet.public.blastapi.io/ext/bc/C/rpc",
+        "type": "evm"
+      },
+      {
+        "url": "https://rpc.ankr.com/avalanche_fuji",
+        "type": "evm"
+      },
+      {
+        "url": "https://avalanche-fuji-c-chain-rpc.publicnode.com",
+        "type": "evm"
+      }
+    ]
+  },
+  "arbitrum_sepolia": {
+    "chain_id": 421614,
+    "chain_aliases": [
+      "arbitrum",
+      "arbitrum_network",
+      "arbitrum_chain",
+      "arbitrum_sepolia_testnet",
+      "arbitrum_sepolia",
+      "arbitrum-network",
+      "arbitrum-chain",
+      "arbitrum-testnet",
+      "arbitrum-sepolia-testnet",
+      "arbitrum-sepolia"
+    ],
+    "chain_name": "Arbitrum Sepolia Testnet",
+    "fees": {
+      "assets": [
+        {
+          "denom": "eth",
+          "gas": 5000000,
+          "gas_price": 1000000000
+        }
+      ]
+    },
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "wei",
+            "exponent": 0
+          },
+          {
+            "denom": "eth",
+            "exponent": 18
+          }
+        ],
+        "base": "eth",
+        "symbol": "ETH"
+      }
+    ],
+    "apps": [
+      {
+        "type": "explorer",
+        "url": "https://sepolia.arbiscan.io/",
+        "tx": "/tx/${tx}",
+        "address": "/address/${address}"
+      }
+    ],
+    "api": [
+      {
+        "url": "https://sepolia-rollup.arbitrum.io/rpc",
+        "type": "evm"
+      },
+      {
+        "url": "https://arbitrum-sepolia-rpc.publicnode.com",
+        "type": "evm"
+      },
+      {
+        "url": "https://arbitrum-sepolia.gateway.tenderly.co",
+        "type": "evm"
+      }
+    ]
+  },
   "base_mainnet": {
     "chain_id": 8453,
     "chain_aliases": [

--- a/data/networks.json
+++ b/data/networks.json
@@ -13,7 +13,7 @@
       "avalanche-c-fuji-testnet",
       "avalanche-c-fuji"
     ],
-    "chain_name": "Avalanche C-Chain Fuji",
+    "chain_name": "Avalanche C-Chain Fuji Testnet",
     "fees": {
       "assets": [
         {

--- a/data/networks.json
+++ b/data/networks.json
@@ -2,14 +2,10 @@
   "avalanche_testnet": {
     "chain_id": 43113,
     "chain_aliases": [
-      "avalanche_c",
-      "avalanche_c_network",
-      "avalanche_c_chain",
+      "avalanche_c_fuji_chain",
       "avalanche_c_fuji_testnet",
       "avalanche_c_fuji",
-      "avalanche-c",
-      "avalanche-c-network",
-      "avalanche-c-chain",
+      "avalanche-c-fuji-chain",
       "avalanche-c-fuji-testnet",
       "avalanche-c-fuji"
     ],
@@ -69,13 +65,8 @@
   "arbitrum_sepolia": {
     "chain_id": 421614,
     "chain_aliases": [
-      "arbitrum",
-      "arbitrum_network",
-      "arbitrum_chain",
       "arbitrum_sepolia_testnet",
       "arbitrum_sepolia",
-      "arbitrum-network",
-      "arbitrum-chain",
       "arbitrum-testnet",
       "arbitrum-sepolia-testnet",
       "arbitrum-sepolia"
@@ -191,13 +182,8 @@
   "base_sepolia": {
     "chain_id": 84532,
     "chain_aliases": [
-      "base",
-      "base_network",
-      "base_chain",
       "base_sepolia_testnet",
       "base_sepolia",
-      "base-network",
-      "base-chain",
       "base-testnet",
       "base-sepolia-testnet",
       "base-sepolia"
@@ -791,10 +777,12 @@
     "chain_id": 97,
     "chain_name": "Binance Smart Chain Testnet",
     "chain_aliases": [
-      "bsc",
       "bsc-testnet",
-      "bsc-chain",
-      "bsc-network"
+      "bsc-testnet-chain",
+      "bsc-testnet-network",
+      "bsc_testnet",
+      "bsc_testnet_chain",
+      "bsc_testnet_network"
     ],
     "assets": [
       {


### PR DESCRIPTION

Related issue: https://github.com/zeta-chain/networks/issues/65

Adding the following networks to our list:

- Avalanche C-Chain Fuji
- Arbitrum Sepolia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Avalanche Testnet (Fuji) blockchain network
	- Added support for Arbitrum Sepolia blockchain network
- **Improvements**
	- Refined existing entries for Base Sepolia and BSC Testnet by updating aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->