### PR TITLE
feat: add Avalanche C-Chain and Arbitrum (Mainnets) in the network list

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -1,4 +1,67 @@
 {
+  "avalanche_mainnet": {
+    "chain_id": 43114,
+    "chain_aliases": [
+      "avalanche_c_chain",
+      "avalanche_c_mainnet",
+      "avalanche_c",
+      "avalanche-c-chain",
+      "avalanche-c-mainnet",
+      "avalanche-c"
+    ],
+    "chain_name": "Avalanche C-Chain Mainnet",
+    "fees": {
+      "assets": [
+        {
+          "denom": "avax",
+          "gas": 5000000,
+          "gas_price": 1000000000
+        }
+      ]
+    },
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "wei",
+            "exponent": 0
+          },
+          {
+            "denom": "avax",
+            "exponent": 18
+          }
+        ],
+        "base": "avax",
+        "symbol": "AVAX"
+      }
+    ],
+    "apps": [
+      {
+        "type": "explorer",
+        "url": "https://subnets.avax.network/c-chain",
+        "tx": "/tx/${tx}",
+        "address": "/address/${address}"
+      }
+    ],
+    "api": [
+      {
+        "url": "https://api.avax.network/ext/bc/C/rpc",
+        "type": "evm"
+      },
+      {
+        "url": "https://ava-mainnet.public.blastapi.io/ext/bc/C/rpc",
+        "type": "evm"
+      },
+      {
+        "url": "https://rpc.ankr.com/avalanche",
+        "type": "evm"
+      },
+      {
+        "url": "https://avalanche.public-rpc.com",
+        "type": "evm"
+      }
+    ]
+  },
   "avalanche_testnet": {
     "chain_id": 43113,
     "chain_aliases": [
@@ -58,6 +121,65 @@
       },
       {
         "url": "https://avalanche-fuji-c-chain-rpc.publicnode.com",
+        "type": "evm"
+      }
+    ]
+  },
+  "arbitrum_mainnet": {
+    "chain_id": 42161,
+    "chain_aliases": [
+      "arbitrum",
+      "arbitrum_network",
+      "arbitrum_chain",
+      "arbitrum-network",
+      "arbitrum-chain",
+      "arbitrum-mainnet"
+    ],
+    "chain_name": "Arbitrum Mainnet",
+    "fees": {
+      "assets": [
+        {
+          "denom": "eth",
+          "gas": 5000000,
+          "gas_price": 1000000000
+        }
+      ]
+    },
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "wei",
+            "exponent": 0
+          },
+          {
+            "denom": "eth",
+            "exponent": 18
+          }
+        ],
+        "base": "eth",
+        "symbol": "ETH"
+      }
+    ],
+    "apps": [
+      {
+        "type": "explorer",
+        "url": "https://arbiscan.io/",
+        "tx": "/tx/${tx}",
+        "address": "/address/${address}"
+      }
+    ],
+    "api": [
+      {
+        "url": "https://arbitrum.drpc.org",
+        "type": "evm"
+      },
+      {
+        "url": "https://arbitrum.blockpi.network/v1/rpc/public",
+        "type": "evm"
+      },
+      {
+        "url": "https://rpc.ankr.com/arbitrum",
         "type": "evm"
       }
     ]


### PR DESCRIPTION
Related issues:
- https://github.com/zeta-chain/infrastructure/issues/2001
- https://github.com/zeta-chain/infrastructure/issues/2000

Adding the following networks to our list:

Avalanche C-Chain Mainnet
Arbitrum Mainnet
