### PR TITLE
Add Kaia Kairos Testnet network

### DIFF
--- a/data/networks.json
+++ b/data/networks.json
@@ -1069,5 +1069,69 @@
         "type": "solana"
       }
     ]
+  },
+  "kaia_testnet": {
+    "type": "testnet",
+    "chain_id": 1001,
+    "chain_aliases": [
+      "kaia_kairos_chain",
+      "kaia_kairos_testnet",
+      "kaia_kairos",
+      "kaia-kairos-chain",
+      "kaia-kairos-testnet",
+      "kaia-kairos"
+    ],
+    "chain_name": "Kaia Kairos Testnet",
+    "fees": {
+      "assets": [
+        {
+          "denom": "kaia",
+          "gas": 5000000,
+          "gas_price": 1000000000
+        }
+      ]
+    },
+    "assets": [
+      {
+        "denoms": [
+          {
+            "denom": "kei",
+            "exponent": 0
+          },
+          {
+            "denom": "gkei",
+            "exponent": 9
+          },
+          {
+            "denom": "kaia",
+            "exponent": 18
+          }
+        ],
+        "base": "kaia",
+        "symbol": "KAIA"
+      }
+    ],
+    "apps": [
+      {
+        "type": "explorer",
+        "url": "https://kaiascan.io",
+        "tx": "/tx/${tx}",
+        "address": "/address/${address}"
+      }
+    ],
+    "api": [
+      {
+        "url": "https://public-en-kairos.node.kaia.io",
+        "type": "evm"
+      },
+      {
+        "url": "https://responsive-green-emerald.kaia-kairos.quiknode.pro",
+        "type": "evm"
+      },
+      {
+        "url": "https://kaia-kairos.blockpi.network/v1/rpc/public",
+        "type": "evm"
+      }
+    ]
   }
 }

--- a/data/networks.json
+++ b/data/networks.json
@@ -1114,7 +1114,7 @@
     "apps": [
       {
         "type": "explorer",
-        "url": "https://kaiascan.io",
+        "url": "https://kairos.kaiascan.io",
         "tx": "/tx/${tx}",
         "address": "/address/${address}"
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Kaia Kairos Testnet (chain ID 1001) with default fees and asset denominations (KAIA / kei / gkei).
  * Integrated multiple RPC endpoints to improve connectivity and redundancy.
  * Added explorer integration to view transactions and addresses for the new testnet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->